### PR TITLE
Minor changes to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@ elm-stuff
 examples/*.js
 examples/elm-script
 examples/elm-script.cmd
+examples/test-*.txt
+examples/subdirectory
 scripts/elm-script
 scripts/elm-script.cmd
 node_modules
-examples/reversed.txt
 elm.exe

--- a/examples/CheckGitStatus.elm
+++ b/examples/CheckGitStatus.elm
@@ -73,7 +73,7 @@ script { arguments, userPrivileges } =
                     )
 
         _ ->
-            Script.fail "Please pass a single parent directory to check all git projects within"
+            Script.fail "Please pass a single parent directory to check all Git projects within"
 
 
 main : Script.Program

--- a/examples/CheckGitStatus.elm
+++ b/examples/CheckGitStatus.elm
@@ -73,7 +73,7 @@ script { arguments, userPrivileges } =
                     )
 
         _ ->
-            Script.fail "Please pass a single parent directory to check within"
+            Script.fail "Please pass a single parent directory to check all git projects within"
 
 
 main : Script.Program

--- a/examples/CopyFile.elm
+++ b/examples/CopyFile.elm
@@ -9,10 +9,10 @@ script : Script.Init -> Script String ()
 script { workingDirectory } =
     let
         sourceFile =
-            File.in_ workingDirectory "reversed.txt"
+            File.in_ workingDirectory "test.txt"
 
         destinationFile =
-            File.in_ workingDirectory "reversed-copied.txt"
+            File.in_ workingDirectory "test-copied.txt"
     in
     File.copy sourceFile destinationFile
 

--- a/examples/DeleteFile.elm
+++ b/examples/DeleteFile.elm
@@ -9,7 +9,7 @@ script : Script.Init -> Script String ()
 script { workingDirectory } =
     let
         file =
-            File.in_ workingDirectory "reversed.txt"
+            File.in_ workingDirectory "test-written.txt"
     in
     File.delete file
 

--- a/examples/ForEach.elm
+++ b/examples/ForEach.elm
@@ -5,23 +5,27 @@ import Script exposing (Script)
 
 script : Script.Init -> Script String ()
 script { arguments } =
-    arguments
-        |> Script.each
-            (\argument ->
-                Script.printLine <|
-                    case String.toFloat argument of
-                        Just value ->
-                            let
-                                squared =
-                                    value * value
-                            in
-                            argument
-                                ++ " squared is "
-                                ++ String.fromFloat squared
+    case arguments of
+        [] ->
+            Script.fail "Requires command line arguments which are numbers."
+        _ ->
+            arguments
+                |> Script.each
+                    (\argument ->
+                        Script.printLine <|
+                            case String.toFloat argument of
+                                Just value ->
+                                    let
+                                        squared =
+                                            value * value
+                                    in
+                                    argument
+                                        ++ " squared is "
+                                        ++ String.fromFloat squared
 
-                        Nothing ->
-                            argument ++ " is not a number!"
-            )
+                                Nothing ->
+                                    argument ++ " is not a number!"
+                    )
 
 
 main : Script.Program

--- a/examples/ForEach.elm
+++ b/examples/ForEach.elm
@@ -8,6 +8,7 @@ script { arguments } =
     case arguments of
         [] ->
             Script.fail "Please provide a list numbers separated by spaces"
+
         _ ->
             arguments
                 |> Script.each

--- a/examples/ForEach.elm
+++ b/examples/ForEach.elm
@@ -7,7 +7,7 @@ script : Script.Init -> Script String ()
 script { arguments } =
     case arguments of
         [] ->
-            Script.fail "Requires command line arguments which are numbers."
+            Script.fail "Please provide a list numbers separated by spaces"
         _ ->
             arguments
                 |> Script.each

--- a/examples/LineCounts.elm
+++ b/examples/LineCounts.elm
@@ -14,7 +14,7 @@ script : Script.Init -> Script String ()
 script { arguments, userPrivileges } =
     case arguments of
         [] ->
-            Script.fail "Requires command line arguments which are paths to files."
+            Script.fail "Please provide a list of file paths separated by spaces"
         _ ->
             List.map (File.readOnly userPrivileges) arguments
                 |> Script.collect getLineCount

--- a/examples/LineCounts.elm
+++ b/examples/LineCounts.elm
@@ -12,20 +12,24 @@ getLineCount file =
 
 script : Script.Init -> Script String ()
 script { arguments, userPrivileges } =
-    List.map (File.readOnly userPrivileges) arguments
-        |> Script.collect getLineCount
-        |> Script.map (List.map2 Tuple.pair arguments)
-        |> Script.thenWith
-            (Script.each
-                (\( fileName, lineCount ) ->
-                    Script.printLine
-                        (fileName
-                            ++ ": "
-                            ++ String.fromInt lineCount
-                            ++ " lines"
+    case arguments of
+        [] ->
+            Script.fail "Requires command line arguments which are paths to files."
+        _ ->
+            List.map (File.readOnly userPrivileges) arguments
+                |> Script.collect getLineCount
+                |> Script.map (List.map2 Tuple.pair arguments)
+                |> Script.thenWith
+                    (Script.each
+                        (\( fileName, lineCount ) ->
+                            Script.printLine
+                                (fileName
+                                    ++ ": "
+                                    ++ String.fromInt lineCount
+                                    ++ " lines"
+                                )
                         )
-                )
-            )
+                    )
 
 
 main : Script.Program

--- a/examples/LineCounts.elm
+++ b/examples/LineCounts.elm
@@ -15,6 +15,7 @@ script { arguments, userPrivileges } =
     case arguments of
         [] ->
             Script.fail "Please provide a list of file paths separated by spaces"
+
         _ ->
             List.map (File.readOnly userPrivileges) arguments
                 |> Script.collect getLineCount

--- a/examples/Miscellaneous.elm
+++ b/examples/Miscellaneous.elm
@@ -42,10 +42,10 @@ script { arguments, networkConnection } =
                             )
 
                 Nothing ->
-                    Script.fail "Requires one command-line argument which is a number"
+                    Script.fail "Please provide a number as the command-line argument"
 
         _ ->
-            Script.fail "Requires one command-line argument which is a number"
+            Script.fail "Please provide one command-line argument which is a number"
 
 
 getCurrentTime : NetworkConnection -> Script String String

--- a/examples/Miscellaneous.elm
+++ b/examples/Miscellaneous.elm
@@ -10,9 +10,9 @@ import Time
 script : Script.Init -> Script String ()
 script { arguments, networkConnection } =
     case arguments of
-        [ digitString ] -> 
+        [ digitString ] ->
             case String.toInt digitString of
-                Just(integer) ->
+                Just integer ->
                     Script.succeed { text = "A", number = integer }
                         |> Script.aside
                             (\model ->
@@ -36,11 +36,17 @@ script { arguments, networkConnection } =
                             (\number ->
                                 if number > 2 then
                                     Script.printLine "Number is greater than 2"
+
                                 else
                                     Script.fail "Number is not greater than 2"
                             )
-                Nothing -> Script.fail "Requires one command-line argument which is a number"
-        _ -> Script.fail "Requires one command-line argument which is a number"
+
+                Nothing ->
+                    Script.fail "Requires one command-line argument which is a number"
+
+        _ ->
+            Script.fail "Requires one command-line argument which is a number"
+
 
 getCurrentTime : NetworkConnection -> Script String String
 getCurrentTime networkConnection =

--- a/examples/Miscellaneous.elm
+++ b/examples/Miscellaneous.elm
@@ -8,35 +8,39 @@ import Time
 
 
 script : Script.Init -> Script String ()
-script { networkConnection } =
-    Script.succeed { text = "A", number = 2 }
-        |> Script.aside
-            (\model ->
-                Script.do
-                    [ Script.printLine model.text
-                    , printCurrentTime networkConnection
-                    , Script.sleep (Duration.seconds 0.5)
-                    ]
-            )
-        |> Script.map .number
-        |> Script.aside
-            (\number ->
-                Script.do
-                    [ Script.printLine (String.fromInt number)
-                    , printCurrentTime networkConnection
-                    , Script.sleep (Duration.seconds 0.5)
-                    , getCurrentTime networkConnection |> Script.ignoreResult
-                    ]
-            )
-        |> Script.thenWith
-            (\number ->
-                if number > 2 then
-                    Script.succeed ()
-
-                else
-                    Script.fail "Ugh, number is too small"
-            )
-
+script { arguments, networkConnection } =
+    case arguments of
+        [ digitString ] -> 
+            case String.toInt digitString of
+                Just(integer) ->
+                    Script.succeed { text = "A", number = integer }
+                        |> Script.aside
+                            (\model ->
+                                Script.do
+                                    [ Script.printLine model.text
+                                    , printCurrentTime networkConnection
+                                    , Script.sleep (Duration.seconds 0.5)
+                                    ]
+                            )
+                        |> Script.map .number
+                        |> Script.aside
+                            (\number ->
+                                Script.do
+                                    [ Script.printLine (String.fromInt number)
+                                    , printCurrentTime networkConnection
+                                    , Script.sleep (Duration.seconds 0.5)
+                                    , getCurrentTime networkConnection |> Script.ignoreResult
+                                    ]
+                            )
+                        |> Script.thenWith
+                            (\number ->
+                                if number > 2 then
+                                    Script.printLine "Number is greater than 2"
+                                else
+                                    Script.fail "Number is not greater than 2"
+                            )
+                Nothing -> Script.fail "Requires one command-line argument which is a number"
+        _ -> Script.fail "Requires one command-line argument which is a number"
 
 getCurrentTime : NetworkConnection -> Script String String
 getCurrentTime networkConnection =

--- a/examples/MoveFile.elm
+++ b/examples/MoveFile.elm
@@ -9,10 +9,10 @@ script : Script.Init -> Script String ()
 script { workingDirectory } =
     let
         sourceFile =
-            File.in_ workingDirectory "reversed.txt"
+            File.in_ workingDirectory "test-copied.txt"
 
         destinationFile =
-            File.in_ workingDirectory "reversed-moved.txt"
+            File.in_ workingDirectory "test-moved.txt"
     in
     File.move sourceFile destinationFile
 

--- a/examples/PathChecking.elm
+++ b/examples/PathChecking.elm
@@ -7,12 +7,13 @@ import Script.File as File
 
 niceScript : Directory permissions -> Script String ()
 niceScript directory =
-    File.read (File.in_ directory "test.txt")
+    File.read (File.in_ directory "subdirectory/../test.txt")
         |> Script.thenWith
             (\contents ->
                 Script.printLine <|
                     String.fromInt (String.length contents)
-                        ++ " characters in test.txt"
+                        ++ " characters in test.txt\r\n\r\n"
+                        ++ "The following lines should indicate a path access error:\r\n\r\n"
             )
 
 

--- a/examples/PathChecking.elm
+++ b/examples/PathChecking.elm
@@ -12,8 +12,8 @@ niceScript directory =
             (\contents ->
                 Script.printLine <|
                     String.fromInt (String.length contents)
-                        ++ " characters in test.txt\r\n\r\n"
-                        ++ "The following lines should indicate a path access error:\r\n\r\n"
+                        ++ " characters in test.txt\n\n"
+                        ++ "The following lines should indicate a path access error:\n\n"
             )
 
 

--- a/examples/PrintEnvironmentVariables.elm
+++ b/examples/PrintEnvironmentVariables.elm
@@ -19,7 +19,7 @@ script { arguments, environment } =
     case arguments of
         [] ->
             Script.fail
-                ("Requires at least one command-line argument specifying"
+                ("Please provide at least one command-line argument specifying"
                     ++ " environment variable names for which to get values."
                 )
 

--- a/examples/PrintEnvironmentVariables.elm
+++ b/examples/PrintEnvironmentVariables.elm
@@ -16,7 +16,14 @@ printEnvironmentVariable environment name =
 
 script : Script.Init -> Script String ()
 script { arguments, environment } =
-    arguments |> Script.each (printEnvironmentVariable environment)
+    case arguments of
+        [] ->
+            Script.fail (
+                "Requires at least one command-line argument specifying" ++
+                " environment variable names for which to get values."
+            )
+        _ ->
+            arguments |> Script.each (printEnvironmentVariable environment)
 
 
 main : Script.Program

--- a/examples/PrintEnvironmentVariables.elm
+++ b/examples/PrintEnvironmentVariables.elm
@@ -18,10 +18,11 @@ script : Script.Init -> Script String ()
 script { arguments, environment } =
     case arguments of
         [] ->
-            Script.fail (
-                "Requires at least one command-line argument specifying" ++
-                " environment variable names for which to get values."
-            )
+            Script.fail
+                ("Requires at least one command-line argument specifying"
+                    ++ " environment variable names for which to get values."
+                )
+
         _ ->
             arguments |> Script.each (printEnvironmentVariable environment)
 

--- a/examples/ReadFile.elm
+++ b/examples/ReadFile.elm
@@ -14,7 +14,7 @@ script { arguments, userPrivileges } =
                 |> Script.thenWith (Script.each (\line -> Script.printLine (String.toUpper line)))
 
         _ ->
-            Script.fail "Please supply the path of one file to read"
+            Script.fail "Please supply the path of one file to read and print out in uppercase"
 
 
 main : Script.Program

--- a/examples/WriteFile.elm
+++ b/examples/WriteFile.elm
@@ -30,7 +30,7 @@ script { workingDirectory, platform } =
             File.in_ workingDirectory "test.txt"
 
         outputFile =
-            File.in_ workingDirectory "reversed.txt"
+            File.in_ workingDirectory "test-written.txt"
 
         lineSeparator =
             Platform.lineSeparator platform

--- a/runner/main.js
+++ b/runner/main.js
@@ -16,14 +16,6 @@ function createTemporaryDirectory() {
   return directoryPath;
 }
 
-function extendedErrorMessage(request, error) {
-  const stackTrace = new Error().stack;
-  // Chop off first two lines which are "Error:" and this method.
-  // Also, anything from XMLHttpRequest.send and above is not useful
-  const revisedTrace = stackTrace.replace(/\s+at XMLHttpRequest.send[\s\S]*/m, "").split("\n").slice(2).join("\n");
-  return "ERROR: " + error.message + "\r\n" + revisedTrace + "\r\n  Failed request: " + JSON.stringify(request) + "\r\n" ;
-}
-
 function exit(code) {
   // First, clean up any temp directories created while running the script
   for (const directoryPath of tempDirectoriesToRemove) {
@@ -74,7 +66,7 @@ function listEntities(request, handleResponse, statsPredicate) {
       });
     handleResponse(results);
   } catch (error) {
-    handleResponse({ message: extendedErrorMessage(request, error) });
+    handleResponse({ message: error.message });
   }
 }
 
@@ -222,7 +214,7 @@ class XMLHttpRequest {
           const contents = new TextDecoder("utf-8").decode(data);
           handleResponse(contents);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "writeFile":
@@ -232,7 +224,7 @@ class XMLHttpRequest {
           Deno.writeFileSync(filePath, contents);
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "listFiles":
@@ -274,7 +266,6 @@ class XMLHttpRequest {
             handleResponse({ error: "notfound" });
           } else {
             console.log(error);
-            console.trace();
             exit(1);
           }
         }
@@ -286,7 +277,7 @@ class XMLHttpRequest {
           Deno.copyFileSync(sourcePath, destinationPath);
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "moveFile":
@@ -296,7 +287,7 @@ class XMLHttpRequest {
           Deno.renameSync(sourcePath, destinationPath);
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "deleteFile":
@@ -305,7 +296,7 @@ class XMLHttpRequest {
           Deno.removeSync(filePath);
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "stat":
@@ -323,7 +314,7 @@ class XMLHttpRequest {
           if (error === Deno.errors.NotFound) {
             handleResponse("nonexistent");
           } else {
-            handleResponse({ message: extendedErrorMessage(request, error) });
+            handleResponse({ message: error.message });
           }
         }
         break;
@@ -333,7 +324,7 @@ class XMLHttpRequest {
           Deno.mkdirSync(directoryPath, { recursive: request.value.recursive });
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "removeDirectory":
@@ -344,7 +335,7 @@ class XMLHttpRequest {
           });
           handleResponse(null);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "createTemporaryDirectory":
@@ -352,7 +343,7 @@ class XMLHttpRequest {
           const directoryPath = createTemporaryDirectory();
           handleResponse(directoryPath);
         } catch (error) {
-          handleResponse({ message: extendedErrorMessage(request, error) });
+          handleResponse({ message: error.message });
         }
         break;
       case "http":


### PR DESCRIPTION
* Makes some of the examples more perspicuous by outputting usage information when the script is run without the necessary arguments
* Modifies the .gitignore to ignore files generated by the examples, and make those file names a bit more uniform
* Modifies one of the error messages from the runner dealing with relative paths (this is triggered by the PathChecking.elm example).
